### PR TITLE
Do not include the java8 classes from XStream

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -85,6 +85,15 @@
                             <goal>shade</goal>
                         </goals>
                         <configuration>
+                            <filters>
+                                <filter>
+                                    <artifact>com.thoughtworks.xstream:xstream</artifact>
+                                    <excludes>
+                                        <exclude>com/thoughtworks/xstream/mapper/LambdaMapper.class</exclude>
+                                        <exclude>com/thoughtworks/xstream/converters/reflection/LambdaConverter.class</exclude>
+                                    </excludes>
+                                </filter>
+                            </filters>
                             <createSourcesJar>true</createSourcesJar>
                             <relocations>
                                 <relocation>


### PR DESCRIPTION
As reported on the [mailing list](https://groups.google.com/forum/#!topic/cukes/tAwLqtWhjcI), Cucumber-JVM release v1.2.3 (and v1.2.4) fails to build for Android. The root cause is that XStream v1.4.8 contains two classes (com.thoughtworks.xstream.mapper.LambdaMapper.class and com.thoughtworks.xstream.converters.reflection.LambdaConverter.class) compiled to the byte code version of Java8 (major version 52), and classes of that byte code version cannot be included in an Android dex file.

This PR filters out those two classes from the cucumber-jvm-deps jar, so that all classes contained can be included in an Android dex file. 
